### PR TITLE
Fix mobile responsiveness and accessibility

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -277,3 +277,17 @@ h1, h2 {
 .dark ::selection {
   background-color: rgba(203, 166, 247, 0.25);
 }
+
+/* Respect reduced motion preference */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+/* Clean tap highlight on mobile */
+a, button {
+  -webkit-tap-highlight-color: transparent;
+}

--- a/components/certifications.tsx
+++ b/components/certifications.tsx
@@ -77,7 +77,7 @@ export function Certifications({ badges }: CertificationsProps) {
         </div>
 
         {/* Badge grid */}
-        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6">
+        <div className="grid grid-cols-1 min-[375px]:grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6">
           {badges.map((badge, i) => (
             <a
               key={badge.name}
@@ -139,7 +139,7 @@ export function Certifications({ badges }: CertificationsProps) {
             className="inline-flex items-center gap-2 text-sm font-[family-name:var(--font-body)]
               text-ink-muted dark:text-night-muted
               hover:text-ink dark:hover:text-night-text
-              transition-colors duration-200"
+              py-3 transition-colors duration-200"
           >
             View all on Credly
             <svg viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -52,7 +52,7 @@ export function Footer() {
               text-ink-muted dark:text-night-muted hover:text-ink dark:hover:text-night-text
               hover:-translate-y-px hover:underline hover:decoration-mauve dark:hover:decoration-mauve-dark
               hover:underline-offset-4 hover:decoration-2
-              transition-all duration-200"
+              py-3 px-1 transition-all duration-200"
           >
             GitHub
           </a>
@@ -65,7 +65,7 @@ export function Footer() {
               text-ink-muted dark:text-night-muted hover:text-ink dark:hover:text-night-text
               hover:-translate-y-px hover:underline hover:decoration-mauve dark:hover:decoration-mauve-dark
               hover:underline-offset-4 hover:decoration-2
-              transition-all duration-200"
+              py-3 px-1 transition-all duration-200"
           >
             LinkedIn
           </a>
@@ -76,7 +76,7 @@ export function Footer() {
               text-ink-muted dark:text-night-muted hover:text-ink dark:hover:text-night-text
               hover:-translate-y-px hover:underline hover:decoration-mauve dark:hover:decoration-mauve-dark
               hover:underline-offset-4 hover:decoration-2
-              transition-all duration-200"
+              py-3 px-1 transition-all duration-200"
           >
             Email
           </a>

--- a/components/gallery/sort-controls.tsx
+++ b/components/gallery/sort-controls.tsx
@@ -167,7 +167,7 @@ export function SortControls({ value, onChange }: SortControlsProps) {
               aria-selected={value === option.value}
               type="button"
               onClick={() => selectOption(option.value)}
-              className={`w-full text-left px-4 py-2.5 text-sm font-[family-name:var(--font-mono)] text-ink dark:text-night-text cursor-pointer transition-colors duration-150 ${
+              className={`w-full text-left px-4 py-3 text-sm font-[family-name:var(--font-mono)] text-ink dark:text-night-text cursor-pointer transition-colors duration-150 ${
                 value === option.value
                   ? 'bg-sapphire/10 dark:bg-sapphire-dark/10'
                   : 'hover:bg-ink/5 dark:hover:bg-night-text/5'

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -123,6 +123,7 @@ export function Hero() {
   }, [updateParallax]);
 
   useEffect(() => {
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
     window.addEventListener("scroll", handleScroll, { passive: true });
     return () => {
       window.removeEventListener("scroll", handleScroll);
@@ -205,7 +206,7 @@ export function Hero() {
             </p>
 
             {/* Social links */}
-            <div ref={socialRef} className="flex gap-1 items-center mt-8 will-change-transform">
+            <div ref={socialRef} className="flex gap-2 items-center mt-8 will-change-transform">
               <a
                 href="https://github.com/aabdur1"
                 target="_blank"
@@ -262,15 +263,15 @@ export function Hero() {
             </div>
 
             {/* Badges — multi-accent pills */}
-            <div ref={badgesRef} className="flex flex-wrap gap-2.5 mt-10 will-change-transform">
+            <div ref={badgesRef} className="flex flex-wrap gap-2 sm:gap-2.5 mt-10 will-change-transform">
               {badges.map((badge, i) => {
                 const s = BADGE_STYLES[badge.accent];
                 return (
                   <span
                     key={badge.text}
-                    className={`inline-flex items-center gap-2 rounded-full px-4 py-2
+                    className={`inline-flex items-center gap-1.5 sm:gap-2 rounded-full px-3 sm:px-4 py-1.5 sm:py-2
                       ${s.bg} border ${s.border} ${s.hoverBorder}
-                      text-[13px] tracking-wide font-[family-name:var(--font-badge)]
+                      text-[11px] sm:text-[13px] tracking-wide font-[family-name:var(--font-badge)]
                       ${s.text}
                       hover:-translate-y-0.5 hover:shadow-card
                       hover:text-ink dark:hover:text-night-text

--- a/components/nav.tsx
+++ b/components/nav.tsx
@@ -37,7 +37,7 @@ export default function Nav() {
         {/* Left: Name — ghosted at top, progressively fades in on scroll */}
         <Link
           href="/"
-          className="nav-wordmark font-[family-name:var(--font-display)] text-2xl sm:text-3xl text-ink dark:text-night-text
+          className="nav-wordmark min-w-0 font-[family-name:var(--font-display)] text-lg sm:text-2xl md:text-3xl text-ink dark:text-night-text
             tracking-tight leading-none"
           style={{
             opacity: resolvedOpacity,

--- a/docs/plans/2026-03-01-mobile-responsiveness.md
+++ b/docs/plans/2026-03-01-mobile-responsiveness.md
@@ -1,0 +1,92 @@
+# Mobile Responsiveness Fixes
+
+## Context
+
+Site audit revealed 7 mobile issues ranging from high to low severity. The site's major layout mechanics (grid collapse, responsive font scaling, touch device detection) are solid. These fixes address touch targets, 320px edge cases, and accessibility.
+
+---
+
+## 1. Footer Link Touch Targets — HIGH
+
+**File:** `components/footer.tsx`
+
+Footer links are plain `text-xs` with no padding — ~12px tall touch targets, far below the 44px minimum.
+
+**Fix:** Add `py-3 px-1` to each footer link for a tappable area. This brings height to ~44px without changing visual appearance significantly.
+
+---
+
+## 2. `prefers-reduced-motion` Support — MEDIUM
+
+**Files:** `app/globals.css`, `components/hero.tsx`
+
+No reduced motion support anywhere. Users with motion sensitivity see all parallax + entrance animations.
+
+**Fix (CSS):** Add global `@media (prefers-reduced-motion: reduce)` that kills animation durations and iteration counts.
+
+**Fix (JS):** In hero.tsx, check `prefers-reduced-motion` before attaching scroll parallax listener — skip entirely if user prefers reduced motion.
+
+---
+
+## 3. Nav Name Overflow at 320px — MEDIUM
+
+**File:** `components/nav.tsx`
+
+"Amir Abdur-Rahim" at `text-2xl` + Gallery pill + toggle exceed 320px viewport width.
+
+**Fix:** Scale nav name: `text-lg sm:text-2xl md:text-3xl` and add `min-w-0` to the Link so flex can shrink it.
+
+---
+
+## 4. Hero Badge Overflow at 320px — MEDIUM
+
+**File:** `components/hero.tsx`
+
+Longest badge ("1st Place — AWS National Cloud Quest") at `text-[13px]` with `px-4` is ~310px, exceeding 272px usable width on 320px screens.
+
+**Fix:** Reduce badge text and padding on mobile: `text-[11px] sm:text-[13px]`, `px-3 sm:px-4 py-1.5 sm:py-2`, `gap-1.5 sm:gap-2`.
+
+---
+
+## 5. Cert Grid Cramped Below 375px — LOW-MEDIUM
+
+**File:** `components/certifications.tsx`
+
+2 columns at 320px = 128px per card with 96px for text after padding. Badge names wrap 3-4 lines.
+
+**Fix:** Use `grid-cols-1 min-[375px]:grid-cols-2` instead of `grid-cols-2` so ultra-narrow devices get single column.
+
+---
+
+## 6. Sort Dropdown Touch Targets — LOW
+
+**File:** `components/gallery/sort-controls.tsx`
+
+Dropdown options have `py-2.5` = 40px total height, 4px short of 44px.
+
+**Fix:** Change `py-2.5` to `py-3`.
+
+---
+
+## 7. Social Link Spacing — LOW
+
+**File:** `components/hero.tsx`
+
+Social icon buttons are 44x44px (good) but only `gap-1` (4px) apart. Apple HIG recommends 8px+.
+
+**Fix:** Change `gap-1` to `gap-2`.
+
+---
+
+## Implementation Order
+
+1. `app/globals.css` — reduced motion media query + tap highlight
+2. `components/hero.tsx` — parallax reduced motion check + badge sizing + social gap
+3. `components/footer.tsx` — link touch targets
+4. `components/nav.tsx` — name text scaling + min-w-0
+5. `components/certifications.tsx` — responsive grid-cols
+6. `components/gallery/sort-controls.tsx` — dropdown padding
+
+## Commit
+
+Single commit: all mobile responsiveness fixes together.


### PR DESCRIPTION
## Summary

- **Touch targets**: Footer links, Credly link, sort dropdown options all padded to 44px minimum
- **320px edge cases**: Nav name scales down, hero badges shrink, cert grid goes single-column below 375px
- **Accessibility**: `prefers-reduced-motion` support — kills all animations globally and skips hero parallax
- **Mobile UX**: Clean tap highlights, wider social link spacing (4px → 8px)

## Test plan

- [ ] iPhone SE (320px): nav name doesn't overflow, badges wrap cleanly, certs single-column
- [ ] Footer links: easily tappable on mobile
- [ ] Enable "Reduce Motion" in OS settings → no animations, no parallax
- [ ] Sort dropdown options: comfortably tappable
- [ ] Desktop: no visual regressions at normal widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)