### PR TITLE
Add resume sections to landing page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,16 @@
 import type { Metadata } from 'next'
 import { Hero } from "@/components/hero";
 import { Certifications } from "@/components/certifications";
+import { Experience } from "@/components/experience";
+import { Projects } from "@/components/projects";
+import { Skills } from "@/components/skills";
+import { Education } from "@/components/education";
 import { PageTransition } from '@/components/page-transition'
 import { getAllBadges } from "@/lib/badges";
 
 export const metadata: Metadata = {
   title: 'Amir Abdur-Rahim — Healthcare Meets Technology',
-  description: 'Personal site of Amir Abdur-Rahim. MS in MIS at UIC, 1st Place AWS National Cloud Quest, Zscaler Zero Trust Architect. Chicago.',
+  description: 'Personal site of Amir Abdur-Rahim. MS in MIS at UIC, 1st Place AWS National Cloud Quest, Zscaler Zero Trust Architect. Experience, projects, certifications, and photography. Chicago.',
   openGraph: {
     title: 'Amir Abdur-Rahim',
     description: 'Healthcare meets technology. Chicago.',
@@ -26,7 +30,11 @@ export default async function Home() {
   return (
     <PageTransition>
       <Hero />
+      <Experience />
+      <Projects />
       <Certifications badges={badges} />
+      <Skills />
+      <Education />
     </PageTransition>
   );
 }

--- a/components/certifications.tsx
+++ b/components/certifications.tsx
@@ -40,7 +40,7 @@ export function Certifications({ badges }: CertificationsProps) {
   return (
     <section
       ref={sectionRef}
-      className="relative py-20 sm:py-28 bg-cream-dark/40 dark:bg-night-card/30"
+      className="relative py-20 sm:py-28"
     >
       {/* Top ornamental divider */}
       <div className="absolute top-0 left-1/2 -translate-x-1/2 flex items-center gap-3 -translate-y-1/2">
@@ -60,7 +60,7 @@ export function Certifications({ badges }: CertificationsProps) {
         >
           <p className="text-[13px] tracking-[0.3em] uppercase font-[family-name:var(--font-mono)]
             text-ink-muted dark:text-night-muted mb-3">
-            <span className="text-peach dark:text-peach-dark">01</span>
+            <span className="text-peach dark:text-peach-dark">03</span>
             <span className="mx-2 text-cream-border dark:text-night-border">/</span>
             Certifications
           </p>

--- a/components/education.tsx
+++ b/components/education.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+export function Education() {
+  const sectionRef = useRef<HTMLElement>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const el = sectionRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setVisible(true);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.1 }
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <section
+      ref={sectionRef}
+      className="relative py-20 sm:py-28"
+    >
+      {/* Top ornamental divider */}
+      <div className="absolute top-0 left-1/2 -translate-x-1/2 flex items-center gap-3 -translate-y-1/2">
+        <div className="h-px w-12 bg-cream-border dark:bg-night-border" />
+        <span className="text-peach dark:text-peach-dark text-xs leading-none">&#9670;</span>
+        <div className="h-px w-12 bg-cream-border dark:bg-night-border" />
+      </div>
+
+      <div className="max-w-5xl mx-auto px-6 sm:px-8">
+        {/* Section header */}
+        <div
+          className="text-center mb-14"
+          style={{
+            opacity: 0,
+            ...(visible ? { animation: "fade-in-up 0.6s ease-out forwards" } : {}),
+          }}
+        >
+          <p className="text-[13px] tracking-[0.3em] uppercase font-[family-name:var(--font-mono)] text-ink-muted dark:text-night-muted mb-3">
+            <span className="text-peach dark:text-peach-dark">05</span>
+            <span className="mx-2 text-cream-border dark:text-night-border">/</span>
+            Education
+          </p>
+          <h2 className="text-3xl sm:text-4xl font-[family-name:var(--font-display)] text-ink dark:text-night-text">
+            Education
+          </h2>
+          <div
+            className="mt-4 mx-auto h-px w-12 bg-mauve dark:bg-mauve-dark origin-center"
+            style={{
+              transform: "scaleX(0)",
+              ...(visible ? { animation: "line-grow 0.8s ease-out 0.3s forwards" } : {}),
+            }}
+          />
+        </div>
+
+        {/* Content area */}
+        <div className="max-w-2xl mx-auto">
+          {/* Entry 1: Master's */}
+          <div
+            style={{
+              opacity: 0,
+              ...(visible ? { animation: "fade-in-up 0.5s ease-out 200ms forwards" } : {}),
+            }}
+          >
+            <p className="text-xs tracking-[0.15em] uppercase font-[family-name:var(--font-mono)] text-peach dark:text-peach-dark mb-1">
+              Expected Fall 2026
+            </p>
+            <h3 className="font-[family-name:var(--font-display)] text-xl sm:text-2xl text-ink dark:text-night-text">
+              Master of Science in Management Information Systems
+            </h3>
+            <p className="text-sm font-[family-name:var(--font-body)] text-ink-muted dark:text-night-muted mt-1">
+              University of Illinois Chicago
+            </p>
+            <div className="flex flex-wrap gap-2 mt-3">
+              {[
+                "Enterprise App Dev",
+                "Systems Analysis",
+                "Info Security",
+                "Project Management",
+                "Healthcare IS",
+                "Advanced DB Management",
+                "Data Mining for Business",
+                "Health Info Management & Analytics",
+              ].map((course) => (
+                <span
+                  key={course}
+                  className="border border-cream-border/80 dark:border-night-border/80 bg-transparent rounded-full px-3 py-1 text-[11px] tracking-wide font-[family-name:var(--font-mono)] text-ink-muted dark:text-night-muted"
+                >
+                  {course}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          {/* Separator */}
+          <div className="h-px bg-cream-border/60 dark:bg-night-border/60 my-8" />
+
+          {/* Entry 2: Bachelor's */}
+          <div
+            style={{
+              opacity: 0,
+              ...(visible ? { animation: "fade-in-up 0.5s ease-out 400ms forwards" } : {}),
+            }}
+          >
+            <h3 className="font-[family-name:var(--font-display)] text-lg sm:text-xl text-ink dark:text-night-text">
+              Bachelor of Arts in Psychology
+            </h3>
+            <p className="text-sm font-[family-name:var(--font-body)] text-ink-muted dark:text-night-muted mt-1">
+              University of Illinois Chicago · May 2020
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/experience.tsx
+++ b/components/experience.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+export function Experience() {
+  const sectionRef = useRef<HTMLElement>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const el = sectionRef.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setVisible(true);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.1 }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <section ref={sectionRef} className="relative py-20 sm:py-28">
+      {/* Ornamental diamond divider at top */}
+      <div className="absolute top-0 left-1/2 -translate-x-1/2 flex items-center gap-3 -translate-y-1/2">
+        <div className="h-px w-12 bg-cream-border dark:bg-night-border" />
+        <span className="text-peach dark:text-peach-dark text-xs leading-none">&#9670;</span>
+        <div className="h-px w-12 bg-cream-border dark:bg-night-border" />
+      </div>
+
+      <div className="max-w-5xl mx-auto px-6 sm:px-8">
+        {/* Section header */}
+        <div
+          className="text-center mb-14"
+          style={{ opacity: 0, ...(visible ? { animation: "fade-in-up 0.6s ease-out forwards" } : {}) }}
+        >
+          <p className="text-[13px] tracking-[0.3em] uppercase font-[family-name:var(--font-mono)] text-ink-muted dark:text-night-muted mb-3">
+            <span className="text-peach dark:text-peach-dark">01</span>
+            <span className="mx-2 text-cream-border dark:text-night-border">/</span>
+            Experience
+          </p>
+          <h2 className="text-3xl sm:text-4xl font-[family-name:var(--font-display)] text-ink dark:text-night-text">
+            Professional Experience
+          </h2>
+          <div
+            className="mt-4 mx-auto h-px w-12 bg-mauve dark:bg-mauve-dark origin-center"
+            style={{ transform: "scaleX(0)", ...(visible ? { animation: "line-grow 0.8s ease-out 0.3s forwards" } : {}) }}
+          />
+        </div>
+
+        {/* Featured experience card */}
+        <div
+          className="max-w-2xl mx-auto rounded-2xl border-l-4 border-peach dark:border-peach-dark
+            bg-cream/80 dark:bg-night/60 border-y border-r border-y-cream-border/60 border-r-cream-border/60
+            dark:border-y-night-border/60 dark:border-r-night-border/60 p-6 sm:p-8"
+          style={{
+            opacity: 0,
+            ...(visible ? { animation: "fade-in-up 0.5s ease-out 200ms forwards" } : {}),
+          }}
+        >
+          <h3 className="text-xl sm:text-2xl font-[family-name:var(--font-display)] text-ink dark:text-night-text mb-1">
+            Chief Medical Scribe
+          </h3>
+          <p className="text-sm font-[family-name:var(--font-body)] text-ink-muted dark:text-night-muted mb-2">
+            ScribeAmerica — Advocate Christ &amp; Condell Medical Centers
+          </p>
+          <p className="text-xs tracking-[0.15em] uppercase font-[family-name:var(--font-mono)] text-peach dark:text-peach-dark mb-5">
+            Aug 2021 – Sep 2023
+          </p>
+          <ul className="space-y-3">
+            <li className="flex gap-3 text-sm text-ink/80 dark:text-night-text/80 leading-relaxed">
+              <span className="mt-2 w-1 h-1 rounded-full bg-peach/60 dark:bg-peach-dark/60 shrink-0" />
+              Supported 6+ hospitalists with real-time EHR documentation using Epic, capturing patient encounters, progress notes, and discharge summaries in high-volume clinical settings.
+            </li>
+            <li className="flex gap-3 text-sm text-ink/80 dark:text-night-text/80 leading-relaxed">
+              <span className="mt-2 w-1 h-1 rounded-full bg-peach/60 dark:bg-peach-dark/60 shrink-0" />
+              Contributed to AI-assisted documentation pilot, helping achieve a 20% productivity improvement. Trained new scribes on Epic workflows and SOAP documentation standards.
+            </li>
+          </ul>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/projects.tsx
+++ b/components/projects.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+const ACCENT_STYLES = {
+  sapphire: {
+    bg: "bg-sapphire/10 dark:bg-sapphire-dark/12",
+    border: "border-sapphire/25 dark:border-sapphire-dark/25",
+    hoverBorder: "hover:border-sapphire/50 dark:hover:border-sapphire-dark/50",
+    dot: "bg-sapphire dark:bg-sapphire-dark",
+    text: "text-ink/80 dark:text-night-text/80",
+    stripe: "border-t-sapphire dark:border-t-sapphire-dark",
+  },
+  mauve: {
+    bg: "bg-mauve/10 dark:bg-mauve-dark/12",
+    border: "border-mauve/25 dark:border-mauve-dark/25",
+    hoverBorder: "hover:border-mauve/50 dark:hover:border-mauve-dark/50",
+    dot: "bg-mauve dark:bg-mauve-dark",
+    text: "text-ink/80 dark:text-night-text/80",
+    stripe: "border-t-mauve dark:border-t-mauve-dark",
+  },
+  lavender: {
+    bg: "bg-lavender/10 dark:bg-lavender-dark/12",
+    border: "border-lavender/25 dark:border-lavender-dark/25",
+    hoverBorder: "hover:border-lavender/50 dark:hover:border-lavender-dark/50",
+    dot: "bg-lavender dark:bg-lavender-dark",
+    text: "text-ink/80 dark:text-night-text/80",
+    stripe: "border-t-lavender dark:border-t-lavender-dark",
+  },
+} as const;
+
+const projects = [
+  {
+    name: "DocDefend+",
+    subtitle: "Clinical Documentation QA Platform",
+    description:
+      "Full-stack app using Claude AI to validate whether clinical notes support billing codes before claim submission. Defensibility scoring, E/M recommendations, and financial impact analysis.",
+    pills: ["React", "Express", "Claude API", "Tailwind"],
+    accent: "sapphire" as const,
+    url: "https://docdefend.vercel.app",
+  },
+  {
+    name: "StudentPM",
+    subtitle: "Project Management Application",
+    description:
+      "JavaFX desktop app with MVC architecture, SQLite integration, and user authentication.",
+    pills: ["JavaFX", "MVC", "SQLite", "Auth"],
+    accent: "sapphire" as const,
+    url: "https://github.com/aabdur1",
+  },
+  {
+    name: "LightERP",
+    subtitle: "Enterprise Resource Planning System",
+    description:
+      "React MVP with Firebase Cloud Firestore and full UML documentation suite.",
+    pills: ["React", "Firebase", "UML"],
+    accent: "mauve" as const,
+    url: "https://github.com/aabdur1",
+  },
+  {
+    name: "CTF & Security Labs",
+    subtitle: "Capture the Flag & Cloud Security",
+    description:
+      "Network forensics, packet analysis, and AWS security labs covering KMS, VPC, S3, and IAM.",
+    pills: ["AWS", "KMS", "VPC", "Forensics"],
+    accent: "lavender" as const,
+    url: null,
+  },
+];
+
+export function Projects() {
+  const sectionRef = useRef<HTMLElement>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const el = sectionRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setVisible(true);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.1 }
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <section
+      ref={sectionRef}
+      className="relative py-20 sm:py-28 bg-cream-dark/40 dark:bg-night-card/30"
+    >
+      {/* Top ornamental divider */}
+      <div className="absolute top-0 left-1/2 -translate-x-1/2 flex items-center gap-3 -translate-y-1/2">
+        <div className="h-px w-12 bg-cream-border dark:bg-night-border" />
+        <span className="text-peach dark:text-peach-dark text-xs leading-none">&#9670;</span>
+        <div className="h-px w-12 bg-cream-border dark:bg-night-border" />
+      </div>
+
+      <div className="max-w-5xl mx-auto px-6 sm:px-8">
+        {/* Section header */}
+        <div
+          className="text-center mb-14"
+          style={{
+            opacity: 0,
+            ...(visible ? { animation: "fade-in-up 0.6s ease-out forwards" } : {}),
+          }}
+        >
+          <p
+            className="text-[13px] tracking-[0.3em] uppercase font-[family-name:var(--font-mono)]
+              text-ink-muted dark:text-night-muted mb-3"
+          >
+            <span className="text-peach dark:text-peach-dark">02</span>
+            <span className="mx-2 text-cream-border dark:text-night-border">/</span>
+            Projects
+          </p>
+          <h2
+            className="text-3xl sm:text-4xl font-[family-name:var(--font-display)]
+              text-ink dark:text-night-text"
+          >
+            Things I&apos;ve Built
+          </h2>
+          <div
+            className="mt-4 mx-auto h-px w-12 bg-mauve dark:bg-mauve-dark origin-center"
+            style={{
+              transform: "scaleX(0)",
+              ...(visible ? { animation: "line-grow 0.8s ease-out 0.3s forwards" } : {}),
+            }}
+          />
+        </div>
+
+        {/* Project grid */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6">
+          {projects.map((project, i) => {
+            const s = ACCENT_STYLES[project.accent];
+
+            const cardContent = (
+              <>
+                {/* Project name */}
+                <h3
+                  className="text-lg font-[family-name:var(--font-display)]
+                    text-ink dark:text-night-text mb-1 leading-tight"
+                >
+                  {project.name}
+                </h3>
+
+                {/* Subtitle */}
+                <p
+                  className="text-sm font-[family-name:var(--font-badge)] italic
+                    text-ink-muted dark:text-night-muted mb-3"
+                >
+                  {project.subtitle}
+                </p>
+
+                {/* Description */}
+                <p
+                  className="text-sm font-[family-name:var(--font-body)]
+                    text-ink/80 dark:text-night-text/70 leading-relaxed mb-4 flex-1"
+                >
+                  {project.description}
+                </p>
+
+                {/* Tech pills */}
+                <div className="flex flex-wrap gap-1.5">
+                  {project.pills.map((pill) => (
+                    <span
+                      key={pill}
+                      className={`inline-flex items-center gap-1 rounded-full px-2.5 py-1
+                        ${s.bg} border ${s.border}
+                        text-[10px] sm:text-[11px] tracking-wide font-[family-name:var(--font-badge)]
+                        ${s.text}`}
+                    >
+                      <span className={`w-1 h-1 rounded-full ${s.dot} shrink-0`} />
+                      {pill}
+                    </span>
+                  ))}
+                </div>
+
+                {/* Arrow icon — only shown when card is a link */}
+                {project.url && (
+                  <div className="absolute top-4 right-4 text-ink-faint/40 dark:text-night-muted/40
+                    group-hover:text-ink-muted dark:group-hover:text-night-muted
+                    transition-colors duration-200">
+                    <svg viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
+                      <path
+                        fillRule="evenodd"
+                        d="M5.22 14.78a.75.75 0 001.06 0l7.22-7.22v5.69a.75.75 0 001.5 0v-7.5a.75.75 0 00-.75-.75h-7.5a.75.75 0 000 1.5h5.69l-7.22 7.22a.75.75 0 000 1.06z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  </div>
+                )}
+              </>
+            );
+
+            const sharedClassName = `group relative flex flex-col p-5 sm:p-6 rounded-2xl
+              border-t-[3px] ${s.stripe}
+              bg-cream/80 dark:bg-night/60
+              border border-cream-border/60 dark:border-night-border/60
+              ${s.hoverBorder}
+              hover:-translate-y-1 hover:shadow-card`;
+
+            const sharedStyle = {
+              opacity: 0,
+              transition:
+                "transform 300ms cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 300ms cubic-bezier(0.34, 1.56, 0.64, 1), border-color 300ms ease",
+              ...(visible
+                ? {
+                    animation: `fade-in-up 0.5s ease-out ${200 + i * 100}ms forwards`,
+                  }
+                : {}),
+            };
+
+            if (project.url) {
+              return (
+                <a
+                  key={project.name}
+                  href={project.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={`${project.name} — ${project.subtitle} (opens in new tab)`}
+                  className={sharedClassName}
+                  style={sharedStyle}
+                >
+                  {cardContent}
+                </a>
+              );
+            }
+
+            return (
+              <div
+                key={project.name}
+                className={sharedClassName}
+                style={sharedStyle}
+              >
+                {cardContent}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/skills.tsx
+++ b/components/skills.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+const PILL_STYLES = {
+  sapphire: {
+    bg: "bg-sapphire/10 dark:bg-sapphire-dark/12",
+    border: "border-sapphire/25 dark:border-sapphire-dark/25",
+    dot: "bg-sapphire dark:bg-sapphire-dark",
+    text: "text-ink/80 dark:text-night-text/80",
+  },
+  mauve: {
+    bg: "bg-mauve/10 dark:bg-mauve-dark/12",
+    border: "border-mauve/25 dark:border-mauve-dark/25",
+    dot: "bg-mauve dark:bg-mauve-dark",
+    text: "text-ink/80 dark:text-night-text/80",
+  },
+  peach: {
+    bg: "bg-peach/10 dark:bg-peach-dark/12",
+    border: "border-peach/25 dark:border-peach-dark/25",
+    dot: "bg-peach dark:bg-peach-dark",
+    text: "text-ink/80 dark:text-night-text/80",
+  },
+  lavender: {
+    bg: "bg-lavender/10 dark:bg-lavender-dark/12",
+    border: "border-lavender/25 dark:border-lavender-dark/25",
+    dot: "bg-lavender dark:bg-lavender-dark",
+    text: "text-ink/80 dark:text-night-text/80",
+  },
+} as const;
+
+const skillCategories = [
+  {
+    label: "Cloud & Security",
+    accent: "sapphire" as const,
+    skills: ["AWS", "EC2", "S3", "VPC", "KMS", "IAM", "CloudFront", "GCP", "Firebase", "Zero Trust"],
+  },
+  {
+    label: "Programming",
+    accent: "mauve" as const,
+    skills: ["Java", "JavaFX", "JavaScript", "React", "Python", "R", "SQL", "HTML/CSS"],
+  },
+  {
+    label: "Healthcare IT",
+    accent: "peach" as const,
+    skills: ["Epic EMR", "EHR Implementation", "Clinical Workflow", "HIPAA", "Medical Documentation"],
+  },
+  {
+    label: "AI & Analytics",
+    accent: "sapphire" as const,
+    skills: ["Claude Code", "Google Colab", "BigQuery", "Looker", "Snowflake"],
+  },
+  {
+    label: "Tools & Methods",
+    accent: "lavender" as const,
+    skills: ["UML Modeling", "Agile/Scrum", "Git", "Systems Analysis", "Vendor Management"],
+  },
+];
+
+export function Skills() {
+  const sectionRef = useRef<HTMLElement>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const el = sectionRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setVisible(true);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.1 }
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <section ref={sectionRef} className="relative py-20 sm:py-28 bg-cream-dark/40 dark:bg-night-card/30">
+      {/* Top ornamental divider */}
+      <div className="absolute top-0 left-1/2 -translate-x-1/2 flex items-center gap-3 -translate-y-1/2">
+        <div className="h-px w-12 bg-cream-border dark:bg-night-border" />
+        <span className="text-peach dark:text-peach-dark text-xs leading-none">&#9670;</span>
+        <div className="h-px w-12 bg-cream-border dark:bg-night-border" />
+      </div>
+
+      <div className="max-w-5xl mx-auto px-6 sm:px-8">
+        {/* Section header */}
+        <div
+          className="text-center mb-14"
+          style={{
+            opacity: 0,
+            ...(visible ? { animation: "fade-in-up 0.6s ease-out forwards" } : {}),
+          }}
+        >
+          <p className="text-[13px] tracking-[0.3em] uppercase font-[family-name:var(--font-mono)]
+            text-ink-muted dark:text-night-muted mb-3">
+            <span className="text-peach dark:text-peach-dark">04</span>
+            <span className="mx-2 text-cream-border dark:text-night-border">/</span>
+            Skills
+          </p>
+          <h2 className="text-3xl sm:text-4xl font-[family-name:var(--font-display)]
+            text-ink dark:text-night-text">
+            Technical Stack
+          </h2>
+          <div
+            className="mt-4 mx-auto h-px w-12 bg-mauve dark:bg-mauve-dark origin-center"
+            style={{
+              transform: "scaleX(0)",
+              ...(visible ? { animation: "line-grow 0.8s ease-out 0.3s forwards" } : {}),
+            }}
+          />
+        </div>
+
+        {/* Skill categories */}
+        <div className="space-y-8">
+          {skillCategories.map((category, i) => {
+            const s = PILL_STYLES[category.accent];
+            return (
+              <div
+                key={category.label}
+                style={{
+                  opacity: 0,
+                  ...(visible
+                    ? { animation: `fade-in-up 0.5s ease-out ${200 + i * 120}ms forwards` }
+                    : {}),
+                }}
+              >
+                {/* Category label with colored dot */}
+                <div className="flex items-center gap-2 mb-3">
+                  <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${s.dot}`} />
+                  <span className="font-[family-name:var(--font-mono)] text-xs tracking-[0.2em] uppercase
+                    text-ink-muted dark:text-night-muted">
+                    {category.label}
+                  </span>
+                </div>
+
+                {/* Skill pills */}
+                <div className="flex flex-wrap gap-2">
+                  {category.skills.map((skill) => (
+                    <span
+                      key={skill}
+                      className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1.5
+                        text-[11px] sm:text-[13px] tracking-wide font-[family-name:var(--font-badge)]
+                        ${s.bg} border ${s.border} ${s.text}`}
+                    >
+                      <span className={`w-1 h-1 rounded-full shrink-0 ${s.dot}`} />
+                      {skill}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/docs/plans/2026-03-02-resume-sections-design.md
+++ b/docs/plans/2026-03-02-resume-sections-design.md
@@ -1,0 +1,109 @@
+# Resume Sections — Landing Page Expansion
+
+## Goal
+
+Incorporate full resume content into the landing page as new editorial sections below Certifications. Site serves dual audience: recruiters/hiring managers and personal brand/community.
+
+## Approach
+
+Editorial Longform — each resume section becomes a numbered, full-bleed editorial section following the existing Catppuccin editorial design system.
+
+## Page Flow
+
+1. Hero (existing)
+2. Experience — `01/`
+3. Projects — `02/`
+4. Certifications — `03/`
+5. Skills — `04/`
+6. Education — `05/`
+7. Footer (existing)
+
+## Section Designs
+
+### 01/ Experience — "Professional Experience"
+
+Single featured card (one role).
+
+- Alternating background (`bg-cream-dark/40 dark:bg-night-card/30`)
+- Card: left peach accent stripe (4px vertical bar)
+- **Role:** "Chief Medical Scribe" in display font (~2xl)
+- **Org:** "ScribeAmerica — Advocate Christ & Condell Medical Centers" body, muted
+- **Date:** "Aug 2021 – Sep 2023" mono tag
+- **Highlights** (2 bullets):
+  - Supported 6+ hospitalists with real-time EHR documentation using Epic
+  - Contributed to AI-assisted documentation pilot — 20% productivity improvement
+- Accent: peach
+
+### 02/ Projects — "Things I've Built"
+
+2-column grid (1-col mobile), `card-hover` treatment.
+
+1. **DocDefend+** (sapphire) — "Clinical Documentation QA Platform" — Full-stack app using Claude AI to validate clinical notes support billing codes. Pills: `React` `Express` `Claude API` `Tailwind`. Live: docdefend.vercel.app
+2. **StudentPM** (sapphire) — "Project Management Application" — JavaFX desktop app with MVC, SQLite, auth. Pills: `JavaFX` `MVC` `SQLite` `Auth`
+3. **LightERP** (mauve) — "Enterprise Resource Planning System" — React MVP with Firebase, full UML docs. Pills: `React` `Firebase` `UML`
+4. **CTF & Security Labs** (lavender) — "Capture the Flag & Cloud Security" — Network forensics, AWS security labs. Pills: `AWS` `KMS` `VPC` `Forensics`
+
+Cards have top accent stripe, link to GitHub/live site where applicable.
+
+### 04/ Skills — "Technical Stack"
+
+5 category rows, each with label + flowing accent-tinted pills (same style as hero badge pills).
+
+| Category | Accent | Skills |
+|----------|--------|--------|
+| Cloud & Security | Sapphire | AWS, EC2, S3, VPC, KMS, IAM, CloudFront, GCP, Firebase, Zero Trust |
+| Programming | Mauve | Java, JavaFX, JavaScript, React, Python, R, SQL, HTML/CSS |
+| Healthcare IT | Peach | Epic EMR, EHR Implementation, Clinical Workflow, HIPAA, Medical Documentation |
+| AI & Analytics | Sapphire | Claude Code, Google Colab, BigQuery, Looker, Snowflake |
+| Tools & Methods | Lavender | UML Modeling, Agile/Scrum, Git, Systems Analysis, Vendor Management |
+
+### 05/ Education — "Education"
+
+Two stacked entries, minimal typography-driven layout.
+
+**Entry 1 (prominent):**
+- "Master of Science in Management Information Systems" — display font xl
+- "University of Illinois Chicago" — body, muted
+- "Expected Fall 2026" — mono tag
+- Coursework pills (no accent tint, just border): Enterprise App Dev, Systems Analysis, Info Security, Project Management, Healthcare IS, Advanced DB Management, Data Mining for Business, Health Info Management & Analytics
+
+**Entry 2 (secondary):**
+- "Bachelor of Arts in Psychology" — display font (smaller)
+- "University of Illinois Chicago · May 2020" — body, muted
+
+Separated by thin horizontal rule.
+
+## Shared Patterns
+
+- Scroll-triggered reveals via IntersectionObserver (same as Certifications)
+- Staggered animation within sections (header → content → details)
+- Alternating section backgrounds (transparent / cream-dark)
+- Mobile-first, 320px safe
+- `prefers-reduced-motion` respected
+- Ornamental diamond dividers between sections
+- Numbered mono labels (`02/`, `03/`, etc.) + display font headings + mauve accent rules
+
+## New Files
+
+- `components/experience.tsx` — Experience section
+- `components/projects.tsx` — Projects section
+- `components/skills.tsx` — Skills section
+- `components/education.tsx` — Education section
+
+## Modified Files
+
+- `app/page.tsx` — Import and render new sections below Certifications
+
+## Future Enhancements
+
+### Healthcare Analytics Project Card
+Add a project card for health data analysis work from the Health Info Management & Analytics course (IDS 506 / similar). This would be a strong addition to the Projects section — concrete evidence of the "healthcare meets technology" positioning using real clinical datasets.
+
+Potential card:
+- **Name:** Healthcare Analytics
+- **Subtitle:** Clinical Data Analysis
+- **Description:** Predictive modeling and statistical analysis on clinical datasets — survival analysis, logistic regression, patient outcome modeling.
+- **Pills:** `R` `Python` `Logistic Regression` `Survival Analysis`
+- **Accent:** peach (healthcare color)
+
+Add when the coursework produces a presentable project or write-up.

--- a/docs/plans/2026-03-02-resume-sections-plan.md
+++ b/docs/plans/2026-03-02-resume-sections-plan.md
@@ -1,0 +1,255 @@
+# Resume Sections Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add four new editorial sections (Experience, Projects, Skills, Education) to the landing page below Certifications, incorporating full resume content.
+
+**Architecture:** Four new client components, each following the Certifications component pattern — IntersectionObserver scroll-triggered reveals, staggered fade-in-up animations, ornamental diamond dividers, numbered mono labels. Inserted into `app/page.tsx` between `<Certifications>` and the footer.
+
+**Tech Stack:** Next.js App Router, React client components, Tailwind CSS 4 (Catppuccin tokens from globals.css), existing animation keyframes.
+
+---
+
+### Task 1: Experience Section
+
+**Files:**
+- Create: `components/experience.tsx`
+
+**Step 1: Create the Experience component**
+
+Write `components/experience.tsx` — a `"use client"` component following the exact Certifications pattern:
+- IntersectionObserver with `threshold: 0.1` and `triggerOnce` (disconnect after first intersection)
+- `visible` state controls animation
+- Section uses alternating background: no background class (transparent — Certifications already uses the tinted bg, so Experience alternates to transparent)
+- Ornamental diamond divider at top (identical to Certifications)
+- Section header: `02 / Experience` mono label, "Professional Experience" display heading, mauve accent rule
+- Single featured card with:
+  - Left peach accent stripe (4px border-left using `border-l-4 border-peach dark:border-peach-dark`)
+  - Role: "Chief Medical Scribe" in `font-display text-2xl`
+  - Org: "ScribeAmerica — Advocate Christ & Condell Medical Centers" in body, muted
+  - Date: "Aug 2021 – Sep 2023" in mono font, small
+  - Two highlight bullets with muted dot markers
+  - Card uses `bg-cream/80 dark:bg-night/60 border border-cream-border/60 dark:border-night-border/60 rounded-2xl p-6 sm:p-8`
+- All elements get staggered `fade-in-up` animations gated on `visible`
+
+**Step 2: Verify in dev server**
+
+Run: `npm run dev`
+Verify: Section appears below Certifications, scroll-triggered animation fires, card renders with peach accent stripe, responsive on mobile.
+
+**Step 3: Commit**
+
+```bash
+git add components/experience.tsx
+git commit -m "feat: add Experience section with ScribeAmerica role card"
+```
+
+---
+
+### Task 2: Projects Section
+
+**Files:**
+- Create: `components/projects.tsx`
+
+**Step 1: Create the Projects component**
+
+Write `components/projects.tsx` — same `"use client"` + IntersectionObserver pattern.
+
+- Alternating background: `bg-cream-dark/40 dark:bg-night-card/30` (tinted)
+- Diamond divider, section header: `03 / Projects`, "Things I've Built", mauve rule
+- 3-column grid: `grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6`
+- Project data as a `const` array:
+
+```ts
+const projects = [
+  {
+    name: "StudentPM",
+    subtitle: "Project Management Application",
+    description: "JavaFX desktop app with MVC architecture, SQLite integration, and user authentication.",
+    pills: ["JavaFX", "MVC", "SQLite", "Auth"],
+    accent: "sapphire" as const,
+    url: "https://github.com/aabdur1",
+  },
+  {
+    name: "LightERP",
+    subtitle: "Enterprise Resource Planning System",
+    description: "React MVP with Firebase Cloud Firestore and full UML documentation suite.",
+    pills: ["React", "Firebase", "UML"],
+    accent: "mauve" as const,
+    url: "https://github.com/aabdur1",
+  },
+  {
+    name: "CTF & Security Labs",
+    subtitle: "Capture the Flag & Cloud Security",
+    description: "Network forensics, packet analysis, and AWS security labs covering KMS, VPC, S3, and IAM.",
+    pills: ["AWS", "KMS", "VPC", "Forensics"],
+    accent: "lavender" as const,
+    url: null,
+  },
+];
+```
+
+- Each card: rounded-2xl, same card styling as cert cards but with a 3px top accent stripe (`border-t-[3px]` with accent color), card-hover treatment via inline transition style (matching certifications pattern), cycling accent hover borders
+- Project name in `font-display text-lg`, subtitle in `font-badge italic text-sm`, description in `text-sm text-muted`, tech pills as small accent-tinted tags matching hero badge style
+- Cards with GitHub URLs get a small external-link icon; CTF card has no link
+- Staggered `fade-in-up` per card: `${200 + i * 100}ms`
+
+**Step 2: Verify in dev server**
+
+Verify: 3-column grid on desktop, stacks on mobile, hover effects work, pills render correctly.
+
+**Step 3: Commit**
+
+```bash
+git add components/projects.tsx
+git commit -m "feat: add Projects section with StudentPM, LightERP, CTF cards"
+```
+
+---
+
+### Task 3: Skills Section
+
+**Files:**
+- Create: `components/skills.tsx`
+
+**Step 1: Create the Skills component**
+
+Write `components/skills.tsx` — same pattern.
+
+- Transparent background (alternating)
+- Diamond divider, section header: `04 / Skills`, "Technical Stack", mauve rule
+- Skills data as a `const` array:
+
+```ts
+const skillCategories = [
+  {
+    label: "Cloud & Security",
+    accent: "sapphire" as const,
+    skills: ["AWS", "EC2", "S3", "VPC", "KMS", "IAM", "CloudFront", "GCP", "BigQuery", "Looker", "Snowflake", "Firebase", "Zero Trust"],
+  },
+  {
+    label: "Programming",
+    accent: "mauve" as const,
+    skills: ["Java", "JavaFX", "JavaScript", "React", "Python", "SQL", "HTML/CSS"],
+  },
+  {
+    label: "Healthcare IT",
+    accent: "peach" as const,
+    skills: ["Epic EMR", "EHR Implementation", "Clinical Workflow", "HIPAA", "Medical Documentation"],
+  },
+  {
+    label: "Tools & Methods",
+    accent: "lavender" as const,
+    skills: ["UML Modeling", "Agile/Scrum", "Git", "Systems Analysis", "Vendor Management"],
+  },
+];
+```
+
+- Each category row: category label in mono font with colored dot (same as hero badge dot), then a `flex flex-wrap gap-2` of pills
+- Pills use the exact hero badge multi-accent style: `bg-{accent}/10 dark:bg-{accent}-dark/12`, `border-{accent}/25`, colored dot, `text-[11px] sm:text-[13px] tracking-wide font-badge`
+- Reuse the `PILL_STYLES` map from the design (same structure as `BADGE_STYLES` in hero.tsx — duplicate it here rather than extracting, keeping components self-contained per YAGNI)
+- Stagger: categories animate in one after another, `${200 + i * 120}ms`
+
+**Step 2: Verify in dev server**
+
+Verify: Four category rows with flowing pills, accent colors correct per category, responsive wrapping.
+
+**Step 3: Commit**
+
+```bash
+git add components/skills.tsx
+git commit -m "feat: add Skills section with categorized accent-tinted pills"
+```
+
+---
+
+### Task 4: Education Section
+
+**Files:**
+- Create: `components/education.tsx`
+
+**Step 1: Create the Education component**
+
+Write `components/education.tsx` — same pattern.
+
+- Alternating background: `bg-cream-dark/40 dark:bg-night-card/30` (tinted)
+- Diamond divider, section header: `05 / Education`, "Education", mauve rule
+- Two entries stacked vertically with a thin `h-px bg-cream-border dark:bg-night-border` separator between them
+- Entry 1 (MS):
+  - "Master of Science in Management Information Systems" in `font-display text-xl sm:text-2xl`
+  - "University of Illinois Chicago" in body, muted
+  - "Expected Spring 2026" in `font-mono text-xs tracking-wide uppercase` with peach color
+  - Coursework pills in a `flex flex-wrap gap-2 mt-3`: plain border pills (no accent tint — `border border-cream-border/80 dark:border-night-border/80 bg-transparent`), mono font at `text-[11px]`
+  - Coursework: Enterprise App Dev, Systems Analysis, Info Security, Project Management, Healthcare IS
+- Entry 2 (BA):
+  - "Bachelor of Arts in Psychology" in `font-display text-lg sm:text-xl`
+  - "University of Illinois Chicago · May 2020" in body, muted
+- Stagger: header animates, then entry 1, then separator, then entry 2
+
+**Step 2: Verify in dev server**
+
+Verify: Two entries render with separator, coursework pills appear, typography hierarchy clear.
+
+**Step 3: Commit**
+
+```bash
+git add components/education.tsx
+git commit -m "feat: add Education section with degrees and coursework"
+```
+
+---
+
+### Task 5: Wire into page.tsx
+
+**Files:**
+- Modify: `app/page.tsx`
+
+**Step 1: Import and render all four sections**
+
+Add imports for Experience, Projects, Skills, Education. Render them inside `<PageTransition>` after `<Certifications>`:
+
+```tsx
+import { Experience } from "@/components/experience";
+import { Projects } from "@/components/projects";
+import { Skills } from "@/components/skills";
+import { Education } from "@/components/education";
+
+// In render:
+<PageTransition>
+  <Hero />
+  <Certifications badges={badges} />
+  <Experience />
+  <Projects />
+  <Skills />
+  <Education />
+</PageTransition>
+```
+
+**Step 2: Update page metadata**
+
+Update the `description` in the page metadata to reflect the expanded content:
+```ts
+description: 'Personal site of Amir Abdur-Rahim. MS in MIS at UIC, 1st Place AWS National Cloud Quest, Zscaler Zero Trust Architect. Experience, projects, certifications, and photography. Chicago.',
+```
+
+**Step 3: Verify full page flow**
+
+Run: `npm run dev`
+Verify: All sections appear in order (Hero → Certs → Experience → Projects → Skills → Education → Footer), scroll progress bar works across the longer page, PageTransition stagger applies to first visit, all scroll-triggered animations fire correctly.
+
+**Step 4: Run lint**
+
+Run: `npm run lint`
+Expected: No errors.
+
+**Step 5: Run build**
+
+Run: `npm run build`
+Expected: Build succeeds with no errors.
+
+**Step 6: Commit**
+
+```bash
+git add app/page.tsx
+git commit -m "feat: wire Experience, Projects, Skills, Education into landing page"
+```


### PR DESCRIPTION
## Summary
- Expand landing page from hero + certifications into full editorial scroll with 5 numbered sections
- **01/ Experience** — ScribeAmerica featured card with peach accent stripe
- **02/ Projects** — DocDefend+, StudentPM, LightERP, CTF & Security Labs (2x2 grid with accent stripes, tech pills, live links)
- **03/ Certifications** — reordered from first to third position (experience leads the narrative now)
- **04/ Skills** — 5 categorized pill rows including new AI & Analytics category (Claude Code, Google Colab, BigQuery, Looker, Snowflake)
- **05/ Education** — Updated to Fall 2026, added 3 current semester courses (Advanced DB Management, Data Mining for Business, Health Info Management & Analytics)
- All sections follow existing Catppuccin editorial patterns: scroll-triggered reveals, staggered animations, ornamental dividers, alternating backgrounds

## Test plan
- [ ] Verify all 5 sections render in order below hero
- [ ] Check scroll-triggered animations fire on each section
- [ ] Verify alternating backgrounds (transparent / tinted)
- [ ] Test dark mode on all sections
- [ ] Test mobile responsiveness (320px iPhone SE)
- [ ] Verify DocDefend+ card links to docdefend.vercel.app
- [ ] Check `prefers-reduced-motion` disables animations

🤖 Generated with [Claude Code](https://claude.com/claude-code)